### PR TITLE
Refactor into a `micro` service, using async/await

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,14 @@ module.exports = async (req, res) => {
     } else {
         // fetch and respond
         const endpoint = req.url.substring(1);
-        const parsed = parse(endpoint);
+        const { protocol, hostname } = parse(endpoint);
+        if (!('http:' === protocol || 'https:' === protocol)) {
+            res.statusCode = 400;
+            res.setHeader('Content-Type', 'application/json');
+            return { error: 'Only absolute URLs are supported' };
+        }
         const proxyHeaders = Object.assign({}, req.headers, {
-            host: parsed.hostname
+            host: hostname
         });
         const response = await fetch(endpoint, {
             headers: proxyHeaders

--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ module.exports = async (req, res) => {
     if (req.url === '/' || req.url === '/favicon.ico') {
         // landing page
         try {
-            const markdownString = await readFile('./readme.md', {encoding: 'utf8'});
+            const markdownString = await readFile('./readme.md', {
+                encoding: 'utf8'
+            });
             const content = await marked(markdownString);
 
             // send homepage
@@ -23,21 +25,22 @@ module.exports = async (req, res) => {
         } catch (err) {
             res.statusCode = 500;
             res.setHeader('Content-Type', 'application/json');
-            return { error: 'Yikes! Report to @gnumanth' }
+            return { error: 'Yikes! Report to @gnumanth' };
         }
     } else {
         // fetch and respond
         const endpoint = req.url.substring(1);
         const parsed = parse(endpoint);
+        const proxyHeaders = Object.assign({}, req.headers, {
+            host: parsed.hostname
+        });
         const response = await fetch(endpoint, {
-          headers: Object.assign({}, req.headers, {
-            'host': parsed.hostname
-          })
+            headers: proxyHeaders
         });
 
         // proxy response
         res.statusCode = response.status;
-        res.setHeader('Content-Type', response.headers.get("content-type"));
+        res.setHeader('Content-Type', response.headers.get('content-type'));
         await pipe(response.body, res);
     }
-}
+};

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const { parse } = require('url');
 const pipe = require('promisepipe');
 const fetch = require('node-fetch');
 const marked = require('marked-promise');
@@ -28,8 +29,13 @@ module.exports = async (req, res) => {
         }
     } else {
         // fetch and respond
-        const endpoint = req.url.substring(1)
-        const response = await fetch(endpoint, { headers: req.headers })
+        const endpoint = req.url.substring(1);
+        const parsed = parse(endpoint);
+        const response = await fetch(endpoint, {
+          headers: Object.assign({}, req.headers, {
+            'host': parsed.hostname
+          })
+        });
 
         // send headers
         res.statusCode = response.status;

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ const cors = access();
 module.exports = async (req, res) => {
     if (cors(req, res)) return;
 
-    // landing page
     if (req.url === '/' || req.url === '/favicon.ico') {
+        // landing page
         try {
             const markdownString = await readFile('./readme.md', {encoding: 'utf8'});
             const content = await marked(markdownString);
@@ -35,7 +35,7 @@ module.exports = async (req, res) => {
           })
         });
 
-        // send headers
+        // proxy response
         res.statusCode = response.status;
         res.setHeader('Content-Type', response.headers.get("content-type"));
         await pipe(response.body, res);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const http = require('http');
 const url = require('url');
-const fetch = require('isomorphic-fetch');
+const fetch = require('node-fetch');
 const marked = require('marked');
 const readFile = require('fs').readFile;
 

--- a/index.js
+++ b/index.js
@@ -3,15 +3,13 @@ const { parse } = require('url');
 const pipe = require('promisepipe');
 const fetch = require('node-fetch');
 const marked = require('marked-promise');
+const access = require('access-control');
 const { readFile } = require('fs-promise');
 
+const cors = access();
+
 module.exports = async (req, res) => {
-    var headers = {};
-    headers["Access-Control-Allow-Origin"] = "*";
-    headers["Access-Control-Allow-Methods"] = "POST, GET, PUT, DELETE, OPTIONS";
-    headers["Access-Control-Allow-Credentials"] = true;
-    headers["Access-Control-Max-Age"] = '86400'; // 24 hours
-    headers["Access-Control-Allow-Headers"] = "X-reqed-With, Access-Control-Allow-Origin, X-HTTP-Method-Override, Content-Type, Authorization, Accept";
+    if (cors(req, res)) return;
 
     // landing page
     if (req.url === '/' || req.url === '/favicon.ico') {

--- a/index.js
+++ b/index.js
@@ -1,67 +1,39 @@
 'use strict';
-const http = require('http');
-const url = require('url');
+const pipe = require('promisepipe');
 const fetch = require('node-fetch');
-const marked = require('marked');
-const readFile = require('fs').readFile;
+const marked = require('marked-promise');
+const { readFile } = require('fs-promise');
 
-var server = http.createServer(function (request, resp) {
+module.exports = async (req, res) => {
     var headers = {};
     headers["Access-Control-Allow-Origin"] = "*";
     headers["Access-Control-Allow-Methods"] = "POST, GET, PUT, DELETE, OPTIONS";
     headers["Access-Control-Allow-Credentials"] = true;
     headers["Access-Control-Max-Age"] = '86400'; // 24 hours
-    headers["Access-Control-Allow-Headers"] = "X-Requested-With, Access-Control-Allow-Origin, X-HTTP-Method-Override, Content-Type, Authorization, Accept";
+    headers["Access-Control-Allow-Headers"] = "X-reqed-With, Access-Control-Allow-Origin, X-HTTP-Method-Override, Content-Type, Authorization, Accept";
 
     // landing page
-    if (request.url === '/' || request.url === '/favicon.ico') {
-      readFile('./readme.md', {encoding: 'utf-8'}, (err, markdownString) => {
-        marked(markdownString, (err, content) => {
-          if (err) {
-            resp.end(JSON.stringify({ error: 'Yikes! Report to @gnumanth'}));
-          }
-          // send headers
-          headers['Content-Type'] = 'text/html';
-          resp.writeHead(200, headers);
-          resp.end(content);
-        });
-      });
+    if (req.url === '/' || req.url === '/favicon.ico') {
+        try {
+            const markdownString = await readFile('./readme.md', {encoding: 'utf8'});
+            const content = await marked(markdownString);
+
+            // send homepage
+            res.setHeader('Content-Type', 'text/html; charset=utf8');
+            res.end(content);
+        } catch (err) {
+            res.statusCode = 500;
+            res.setHeader('Content-Type', 'application/json');
+            return { error: 'Yikes! Report to @gnumanth' }
+        }
     } else {
-      //fetch and respond
-      fetch(request.url.replace('/',''))
-      .then(response => {
-        let contentType = response.headers.get("content-type");
+        // fetch and respond
+        const endpoint = req.url.substring(1)
+        const response = await fetch(endpoint, { headers: req.headers })
+
         // send headers
-        headers['Content-Type'] = contentType;
-        resp.writeHead(200, headers);
-
-        // The below shall be a module later ;)
-        if (!!~contentType.indexOf('json')) {
-          return response.json();
-        }
-        else if (!!~contentType.indexOf('text')) {
-          type = 'text'
-          return response.text();
-        }
-        else if (!!~contentType.indexOf('blob')) {
-          type = 'blob'
-          return response.blob();
-        }
-        else if (!!~contentType.indexOf('buffer')) {
-          type = 'buffer'
-          return response.arrayBuffer();
-        } 
-      })
-      .then(data => resp.end(JSON.stringify(data)))
-      .catch(error => {
-        resp.end(JSON.stringify({ error: error.toString()}));
-      });
+        res.statusCode = response.status;
+        res.setHeader('Content-Type', response.headers.get("content-type"));
+        await pipe(response.body, res);
     }
-});
-
-var port = process.env.PORT || 3000;
-server.listen(port, function() {
-    console.log("Server running at http://127.0.0.1/ on port " + port);
-});
-
-
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "start": "node index.js",
+    "start": "micro index.js",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect"
   },

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     ""
   ],
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1",
     "marked": "^0.3.6",
+    "node-fetch": "^2.0.0-alpha.3",
     "snyk": "^1.25.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -26,8 +26,11 @@
     ""
   ],
   "dependencies": {
-    "marked": "^0.3.6",
+    "fs-promise": "^2.0.2",
+    "marked-promise": "^2.0.0",
+    "micro": "^7.3.2",
     "node-fetch": "^2.0.0-alpha.3",
+    "promisepipe": "^2.0.0",
     "snyk": "^1.25.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "marked-promise": "^2.0.0",
     "micro": "^7.3.2",
     "node-fetch": "^2.0.0-alpha.3",
-    "promisepipe": "^2.0.0",
+    "promisepipe": "^2.0.0"
+  },
+  "devDependencies": {
     "snyk": "^1.25.0"
   },
-  "devDependencies": {},
   "snyk": true
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     ""
   ],
   "dependencies": {
+    "access-control": "^1.0.0",
     "fs-promise": "^2.0.2",
     "marked-promise": "^2.0.0",
     "micro": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "h3manth.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": "^6.0.0"
   },
   "scripts": {
     "start": "micro index.js",


### PR DESCRIPTION
Hey there! I was trying to use https://cors.now.sh and realized that it more or less only handles JSON endpoints. What started out as a small patch for piping the proxy response directly, instead of interpreting it based on the `Content-Type`, turned into an overall refactor using `micro` and ES7 async/await.

The code is now shorter and hopefully more readable with no more nesting callbacks, etc. But most importantly better compatibility.

For example, now these work: https://cors-now-uraqlhopyt.now.sh/https://zeit.co or https://cors-now-uraqlhopyt.now.sh/http://playerservices.streamtheworld.com/pls/KSANFMAAC.pls

Cheers! 🍻