### PR TITLE
Add Dockerfile and `now.json` for ZEIT Serverless Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM mhart/alpine-node:10 as base
+WORKDIR /usr/src
+COPY package.json /usr/src/
+RUN yarn --production
+COPY . .
+
+FROM mhart/alpine-node:base-10
+WORKDIR /usr/src
+ENV NODE_ENV="production"
+COPY --from=base /usr/src .
+CMD ["node", "./node_modules/.bin/micro"]

--- a/now.json
+++ b/now.json
@@ -1,0 +1,6 @@
+{
+	"type": "docker",
+	"features": {
+		"cloud": "v2"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "email": "hemanth.hm@gmail.com",
     "url": "h3manth.com"
   },
-  "engines": {
-    "node": "^6.0.0"
-  },
   "scripts": {
     "start": "micro index.js",
     "snyk-protect": "snyk protect",
@@ -22,14 +19,11 @@
     "index.js",
     "readme.md"
   ],
-  "keywords": [
-    ""
-  ],
   "dependencies": {
     "access-control": "^1.0.0",
     "fs-promise": "^2.0.2",
     "marked-promise": "^2.0.0",
-    "micro": "^7.3.2",
+    "micro": "^9.3.2",
     "promisepipe": "^2.0.0",
     "snyk": "^1.46.0"
   },


### PR DESCRIPTION
This way the deployment does not always need to be scaled to 1.

See: https://zeit.co/blog/serverless-docker

Example: https://cors-now-jlnmhkimym.now.sh